### PR TITLE
Update VMdeploy.json

### DIFF
--- a/VMdeploy.json
+++ b/VMdeploy.json
@@ -71,7 +71,9 @@
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[resourceGroup().location]",
       "apiVersion": "2018-12-01",
-      "dependsOn": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups',variables('HyperVHost-NSG'))]"
+      ],
       "tags": {
         "Purpose": "LabDeployment"
       },


### PR DESCRIPTION
Deployment of vNet was failing due to being unable to locate the NSG.  Added the depends on statement in the vNet code block to fix.